### PR TITLE
Reverse proxy HTTP frontend support

### DIFF
--- a/src/admin_login.php
+++ b/src/admin_login.php
@@ -20,7 +20,7 @@
 <div id="wrapper">
 <?php Helper::CreateUserListTopbar(); ?>
 <div id="content">
-<form class="wide" method="post" action="<?php print $_SERVER["PHP_SELF"]?>">
+<form class="wide" method="post" action="<?php print Helper::SelfPath()?>">
 
 <h1><?php print __("ADMIN_LOGIN")?></h1>
 

--- a/src/config_original.php
+++ b/src/config_original.php
@@ -72,6 +72,11 @@
   // Leave the code empty ('') to prevent people to create user accounts theirselves.
   define('PUBLIC_USER_CREATION_CODE', '');
 
+  //Specifies the root url that the Doma server is running behind if doma is behind a revers proxy.
+  //Example Doma frontend running on mydomain.com/ol/ specify the root_url to '/ol'
+  //this ensures that correct paths are given back to the users browser
+  define('ROOT_URL', '');
+
   // *********************************************************************************************************
   //   APPEARANCE SETTINGS
   // *********************************************************************************************************

--- a/src/create.php
+++ b/src/create.php
@@ -18,7 +18,7 @@
 <body id="createBody">
 <div id="wrapper">
 <div id="content">
-<form method="post" action="<?php print $_SERVER['PHP_SELF']; ?>">
+<form method="post" action="<?php print Helper::SelfPath(); ?>">
 
 <?php if(count($vd["Errors"]) == 0) { ?>
 <h1><?php print __("SITE_SUCCESSFULLY_CREATED_TITLE")?></h1>

--- a/src/edit_map.php
+++ b/src/edit_map.php
@@ -22,7 +22,7 @@
 <div id="wrapper">
 <?php Helper::CreateTopbar() ?>
 <div id="content">
-<form class="wide" method="post" action="<?php print $_SERVER["PHP_SELF"]; ?>?<?php print Helper::CreateQuerystring(getCurrentUser(), isset($vd["MapID"]) ? $vd["MapID"] : null); ?>" enctype="multipart/form-data">
+<form class="wide" method="post" action="<?php print Helper::SelfPath(); ?>?<?php print Helper::CreateQuerystring(getCurrentUser(), isset($vd["MapID"]) ? $vd["MapID"] : null); ?>" enctype="multipart/form-data">
 
 <h1><?php print $vd["Title"]; ?></h1>
 

--- a/src/edit_user.controller.php
+++ b/src/edit_user.controller.php
@@ -269,7 +269,7 @@
       if($isAdmin) $atoms[] = "mode=admin";
       if($user->ID) $atoms[] = Helper::CreateQuerystring($user);
       
-      $viewData["FormActionURL"] = $_SERVER["PHP_SELF"] . (count($atoms) > 0 ? "?". join("&amp;", $atoms) : "");
+      $viewData["FormActionURL"] = Helper::SelfPath() . (count($atoms) > 0 ? "?". join("&amp;", $atoms) : "");
       
       $viewData["Errors"] = $errors;
       $viewData["IsAdmin"] = $isAdmin;

--- a/src/enter_public_creation_code.php
+++ b/src/enter_public_creation_code.php
@@ -20,7 +20,7 @@
 <div id="wrapper">
 <?php Helper::CreateUserListTopbar() ?>
 <div id="content">
-<form class="wide" method="post" action="<?php print $_SERVER["PHP_SELF"]?>">
+<form class="wide" method="post" action="<?php print Helper::SelfPath()?>">
 
 <h1><?php print __("ADD_USER_PROFILE_TITLE")?></h1>
 

--- a/src/include/helper.php
+++ b/src/include/helper.php
@@ -106,9 +106,16 @@
     public static function ServerPath($path)
     {
       if(substr($path, 0, 1) == "/") $path = substr($path, 1);
-      return PROJECT_DIRECTORY . $path;
+      return ROOT_URL . PROJECT_DIRECTORY . $path;
     }
 
+    /**
+     * Creates a php[self] url 
+     */
+    public static function SelfPath() 
+    {
+      return ROOT_URL . $_SERVER['PHP_SELF'];
+    }
     /**
     * Creates a rooted path on the local machine e g c:\inetpub\wwwroot\subdir/index.php.
     *

--- a/src/index.php
+++ b/src/index.php
@@ -36,7 +36,7 @@
 <div id="wrapper">
 <?php Helper::CreateTopbar() ?>
 <div id="content">
-<form method="get" action="<?php print $_SERVER["PHP_SELF"]?>?<?php print Helper::CreateQuerystring(getCurrentUser())?>">
+<form method="get" action="<?php print Helper::SelfPath()?>?<?php print Helper::CreateQuerystring(getCurrentUser())?>">
 <input type="hidden" name="user" value="<?php print getCurrentUser()->Username;?>"/>
 <?php if(count($vd["Errors"]) > 0) { ?>
 <ul class="error">

--- a/src/login.php
+++ b/src/login.php
@@ -20,7 +20,7 @@
 <div id="wrapper">
 <?php Helper::CreateTopbar() ?>
 <div id="content">
-<form class="wide" method="post" action="<?php print $_SERVER["PHP_SELF"]?>?<?php print Helper::CreateQuerystring(getCurrentUser())?>">
+<form class="wide" method="post" action="<?php print Helper::SelfPath()?>?<?php print Helper::CreateQuerystring(getCurrentUser())?>">
 
 <h1><?php print __("LOGIN")?></h1>
 

--- a/src/send_new_password.php
+++ b/src/send_new_password.php
@@ -20,7 +20,7 @@
 <div id="wrapper">
 <?php Helper::CreateTopbar() ?>
 <div id="content">
-<form class="wide" method="post" action="<?php print $_SERVER["PHP_SELF"]?>?<?php print Helper::CreateQuerystring(getCurrentUser())?>">
+<form class="wide" method="post" action="<?php print Helper::SelfPath()?>?<?php print Helper::CreateQuerystring(getCurrentUser())?>">
 
 <h1><?php print __("SEND_NEW_PASSWORD_TITLE")?></h1>
 

--- a/src/show_map.php
+++ b/src/show_map.php
@@ -84,7 +84,7 @@
 </div>
 
 <div id="content">
-<form id="frm" method="post" action="<?php print $_SERVER['PHP_SELF']; ?>">
+<form id="frm" method="post" action="<?php print Helper::SelfPath(); ?>">
 <?php if(isset($vd["ProcessRerun"]) && $vd["RerunMaps"]!="") {?>
   <input id="rerun_maps" type="hidden" value="<?php print $vd["RerunMaps"]; ?>" />
   <input id="base_url" type="hidden" value="<?php print BASE_URL; ?>" />

--- a/src/users.php
+++ b/src/users.php
@@ -31,7 +31,7 @@
 <div id="wrapper">
 <?php Helper::CreateUserListTopbar(); ?>
 <div id="content">
-<form method="post" action="<?php print $_SERVER['PHP_SELF']; ?>">
+<form method="post" action="<?php print Helper::SelfPath(); ?>">
 
 <div id="rssIcon"><a href="rss.php"><img src="gfx/feed-icon-28x28.png" alt="<?php print __("RSS_FEED")?>" title="<?php print __("RSS_FEED")?>" /></a></div>
 


### PR DESCRIPTION
Added support for ROOT_URL parameter to be used when DOMA server is behind a reverse proxy frontend eq nginx, HAProxy.

ROOT_URL is appended to action URLs to ensure client browser is issuing the action to correct frontend path. 

Docker-compose based example can be provided to show the use case. 