### PR TITLE
Fix for MySQL 5.7

### DIFF
--- a/src/include/data_access.php
+++ b/src/include/data_access.php
@@ -165,7 +165,7 @@
              "WHERE UserID='$userID' AND ".
              "(ProtectedUntil IS NULL OR ProtectedUntil<='$now' OR UserID='$requestingUserID')".
              ($categoryID ? "AND CategoryID='$categoryID'" : "").
-             "ORDER BY Date ASC";
+             "ORDER BY Year ASC";
       $rs = self::Query($sql);
 
       $years = array();


### PR DESCRIPTION
MySQL 5.7 have restricted the default sql mode so the query in DataAccess::GetYearsByUserIDAndGategoryID() throws error 3065:
"Expression #1 of ORDER BY clause is not in SELECT list, references column 'doma.doma_maps.Date' which is not in SELECT list; this is incompatible with DISTINCT"