### PR TITLE
Bugfix: When deleting a map, the blank map file was left on disk

### DIFF
--- a/src/include/data_access.php
+++ b/src/include/data_access.php
@@ -248,6 +248,7 @@
       $uploadDir = Helper::LocalPath(MAP_IMAGE_PATH ."/");
       self::DeleteMapImage($map);
       self::DeleteThumbnailImage($map);
+      self::DeleteBlankMapImage($map);
       $map->Delete();
     }
 


### PR DESCRIPTION
I found a bug.
- A map can have a blank map file (without track)
- When deleting a map, the blank map image file is NOT deleted from disk.
- The fix calls the existing function for deleting a blank map image.

This bug is not critical, but still annoying when minimizing disk space usage.