### PR TITLE
Bugfix/delete blank map file on map delete

### DIFF
--- a/src/include/data_access.php
+++ b/src/include/data_access.php
@@ -568,6 +568,7 @@
       {
         self::DeleteMapImage($m);
         self::DeleteThumbnailImage($m);
+        self::DeleteBlankMapImage($map);
       }
       $id = mysqli_real_escape_string($GLOBALS["dbCon"], $id);
       $sql = "DELETE FROM `". DB_MAP_TABLE ."` WHERE UserID='$id'";


### PR DESCRIPTION
Found another place with the same issue:
Blank map files are not deleted from disk when deleting a user.