### PR TITLE
Performance tuning users.php (rewrite a query + add index)

### DIFF
--- a/src/include/data_access.php
+++ b/src/include/data_access.php
@@ -590,10 +590,13 @@
       }
 
       $ret = array();
-      $sql = "SELECT * FROM `". DB_MAP_TABLE ."` a ".
-             "INNER JOIN `". DB_MAP_TABLE ."` b ".
-             "ON a.ID=b.ID ".
-             "WHERE a.`$field`=(SELECT MAX(`$field`) FROM `". DB_MAP_TABLE ."` WHERE UserID=b.UserID AND (ProtectedUntil IS NULL OR ProtectedUntil<='$now' OR UserID='$requestingUserID'))";
+      $sql = "SELECT maps.* FROM `". DB_MAP_TABLE ."` maps " .
+             "INNER JOIN (".
+             "    SELECT UserID, MAX(`$field`) AS value" .
+             "    FROM `". DB_MAP_TABLE ."`" .
+             "    WHERE (ProtectedUntil IS NULL OR ProtectedUntil<='$now' OR UserID='$requestingUserID')" .
+             "    GROUP BY UserID" .
+             ") VI ON maps.UserID = VI.UserID AND maps.`$field` = VI.value";
       $rs = self::Query($sql);
       while($r = mysqli_fetch_assoc($rs))
       {

--- a/src/include/db_scripts.php
+++ b/src/include/db_scripts.php
@@ -80,6 +80,11 @@
               // 3drerun.worldofo.com ID
               "ALTER TABLE `". DB_MAP_TABLE ."` ADD `RerunID` INT ",
               "ALTER TABLE `". DB_MAP_TABLE ."` ADD `RerunTries` INT ")
+            ),
+      array("version" => "3.0.9",
+            "scripts" => array(
+              // index for speeding up users.php
+              "ALTER TABLE `". DB_COMMENT_TABLE ."` ADD INDEX `Comments_MapID` (`MapID`)")
            )
     );
     return array_filter($allScripts, "filter");


### PR DESCRIPTION
- We have about 5500 maps in the database and the frontpage (users.php) took about 10 seconds to load.
- GetLastMapsPerUser took almost 7sec and GetLastComments took 1,7sec
- I rewrote the SQL for GetLastMapsPerUser to use an inline view with a GROUP BY and equivalent timing and access control as the original query.
- I compared the output and got the exact same result as before. 
- I also added an index on the doma_comments table (for the next doma version).
- You can check out the performance at: https://kartarkiv.nydalen.idrett.no/ (0,5sec response time)

Here is a concrete version of the SQL query:
SELECT maps.* FROM doma_maps maps
INNER JOIN (
	SELECT UserID, MAX(Date) AS value
    FROM doma_maps
    WHERE (ProtectedUntil IS NULL OR ProtectedUntil<='2020-01-21' OR UserID='0')
    GROUP BY UserID
) VI ON maps.UserID = VI.UserID AND maps.Date = VI.value