### PR TITLE
Initialize Handles to avoid null warning when missing Handles in jpg extension

### DIFF
--- a/src/include/quickroute_jpeg_extension_data.php
+++ b/src/include/quickroute_jpeg_extension_data.php
@@ -718,7 +718,7 @@
   class QRHandles
   // This class implements searching for the handle that corresponds to a certain segment and time
   {
-    public $handles;
+    public $handles = [];
     private $index = 0;
     private $segments = array();
     function __construct($handles)


### PR DESCRIPTION
I'm cleaning up warnings in our log... We have a map that created a warning on line 728 in quickroute_jpeg_extension_data.php because session->Handles could not be iterated.

I debugged the parsing of the metadata and found that the Handles tag did not contain any data ($handleCount=0), causing the initializing section to be skipped. This resulted in $session->Handles returning null instead of a valid array.

This fix initialize the $handles variable to an empty array and avoids the warning.

This warning only one of our 5500 maps, so I guess it's a pretty rare edge case.

If you're interested, the map is this one:
https://kartarkiv.nydalen.idrett.no/show_map.php?user=h%C3%A5vardhaga&map=3978 