### PR TITLE
Add api key to static google map + remove deprecated sensor parameter

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="style.css?v=<?php print DOMA_VERSION; ?>" type="text/css" />
   <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.php?<?php print Helper::CreateQuerystring(getCurrentUser())?>" />
   <script src="js/jquery/jquery-1.7.1.min.js" type="text/javascript"></script>
-  <script src="https://maps.googleapis.com/maps/api/js?key=<?php print GOOGLE_MAPS_API_KEY; ?>&amp;sensor=false&amp;language=<?php print Session::GetLanguageCode(); ?>" type="text/javascript"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?key=<?php print GOOGLE_MAPS_API_KEY; ?>&amp;language=<?php print Session::GetLanguageCode(); ?>" type="text/javascript"></script>
   <script src="js/overview_map.js?v=<?php print DOMA_VERSION; ?>" type="text/javascript"></script>
   <?php if($vd["DisplayMode"] == "overviewMap") { ?>
     <script type="text/javascript">

--- a/src/js/show_map.js
+++ b/src/js/show_map.js
@@ -166,7 +166,7 @@ function reloadGM()
 {
   if($("#gmap").size())
   {
-    $("#gmap").html("<a href='"+$("#gmap_url").val()+"' target='_blank'><img src='https://maps.googleapis.com/maps/api/staticmap?center="+$("#gmap_coordinates").val()+"&amp;zoom=6&amp;size=174x"+$("#wrapper").height()+"&amp;maptype=terrain&amp;markers=color:red%7C"+$("#gmap_coordinates").val()+"&amp;sensor=false&amp;language="+$("#gmap_lang").val()+"'></a>");
+    $("#gmap").html("<a href='"+$("#gmap_url").val()+"' target='_blank'><img src='https://maps.googleapis.com/maps/api/staticmap?center="+$("#gmap_coordinates").val()+"&amp;zoom=6&amp;size=174x"+$("#wrapper").height()+"&amp;maptype=terrain&amp;markers=color:red%7C"+$("#gmap_coordinates").val()+"&amp;language="+$("#gmap_lang").val()+"&amp;key="+$("#gmap_key").val()+"'></a>");
   }
 }
 

--- a/src/show_map.php
+++ b/src/show_map.php
@@ -29,7 +29,7 @@
   ?>
   <script src="js/common.js?v=<?php print DOMA_VERSION; ?>" type="text/javascript"></script>
   <?php if(isset($vd["OverviewMapData"])) { ?>
-    <script src="https://maps.googleapis.com/maps/api/js?key=<?php print GOOGLE_MAPS_API_KEY; ?>&amp;sensor=false&amp;language=<?php print $lang; ?>" type="text/javascript"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<?php print GOOGLE_MAPS_API_KEY; ?>&amp;language=<?php print $lang; ?>" type="text/javascript"></script>
     <script src="js/overview_map.js" type="text/javascript"></script>
     <script type="text/javascript">
       <!--

--- a/src/show_map.php
+++ b/src/show_map.php
@@ -198,6 +198,7 @@ if($map->IsGeocoded)
   print '<input id="gmap_coordinates" type="hidden" value="'.$coordinates.'" />';
   print '<input id="gmap_url" type="hidden" value="'.$vd["GoogleMapsUrl"].'" />';
   print '<input id="gmap_lang" type="hidden" value="'.Session::GetLanguageCode().'" />';
+  print '<input id="gmap_key" type="hidden" value="'.GOOGLE_MAPS_API_KEY.'" />';
   print '<div id="gmap">';
   print '</div>';
 }

--- a/src/users.php
+++ b/src/users.php
@@ -16,7 +16,7 @@
   <script type="text/javascript" src="js/jquery/jquery-1.7.1.min.js"></script>
   <script src="js/common.js?v=<?php print DOMA_VERSION; ?>" type="text/javascript"></script>
   <?php if($vd["OverviewMapData"] != null) { ?>
-    <script src="https://maps.googleapis.com/maps/api/js?key=<?php print GOOGLE_MAPS_API_KEY; ?>&amp;sensor=false&amp;language=<?php print Session::GetLanguageCode(); ?>" type="text/javascript"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<?php print GOOGLE_MAPS_API_KEY; ?>&amp;language=<?php print Session::GetLanguageCode(); ?>" type="text/javascript"></script>
     <script src="js/overview_map.js?v=<?php print DOMA_VERSION; ?>" type="text/javascript"></script>
     <script type="text/javascript">
       <!--


### PR DESCRIPTION
A lot of doma archives have a broken google map to the top right in show_map.php.
This is because Google now demands an API key in their static maps api.
https://developers.google.com/maps/documentation/maps-static/get-api-key
This PR adds the Google Maps Api key constant to this request.

I've also remove the no longer required sensor parameter to avoid Javascript console warnings.
https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required

Here is a map in Nydalens doma with this fix: 
https://kartarkiv.nydalen.idrett.no/show_map.php?user=rune&map=5618