### PR TITLE
Test if thumbnail is GdImage

### DIFF
--- a/src/include/image_is_resizable.php
+++ b/src/include/image_is_resizable.php
@@ -5,7 +5,7 @@
   if(file_exists($filename))
   {
     $image = Helper::ImageCreateFromGeneral($filename);
-    if(is_resource($image))
+    if(is_resource($image) || $image instanceof \GdImage)
     {
       ImageDestroy($image);
       $result = 1;


### PR DESCRIPTION
In PHP 8, GD returns GdImage objects and not resources. To check if a thumbnail could be created, `is_resource()` was used. Since the thumbnail is no longer a resource, this check now fails and the default thumbnail was used for all uploaded maps.

See https://php.watch/versions/8.0/gdimage#gdimage-is-resource

Note that I only have access to a system with PHP 8. According to the linked document, this fix works in PHP 7 as well, but was not tested by me. Not sure about earlier versions.